### PR TITLE
fix: Resolve Vite manifest error for authentication pages

### DIFF
--- a/AUTH_SETUP.md
+++ b/AUTH_SETUP.md
@@ -12,8 +12,8 @@ php artisan subscription:install-auth
 
 This command will:
 - **Setup Inertia.js infrastructure**: Creates `app.blade.php` layout and Inertia middleware
-- **Publish authentication components**: Vue 3 authentication pages and components
-- **Configure frontend**: Updates `app.js` to include auth page resolution
+- **Publish authentication components**: Vue 3 authentication pages and components to main directories
+- **Configure frontend**: Creates/updates `app.js` with standard Inertia page resolution
 - **Setup build tools**: Publishes `package.json`, `vite.config.js`, `tailwind.config.js`, etc.
 - **Update User model**: Adds subscription traits to your User model
 - **Publish configuration**: Package configuration files
@@ -120,14 +120,38 @@ The authentication system provides the following routes:
 4. **Password Reset**: Full password reset functionality
 5. **Subscription Access**: After login, users are redirected to subscription plans
 
+## File Structure
+
+After running the install command, authentication files are published to:
+
+```
+resources/
+├── js/
+│   ├── Pages/
+│   │   └── Auth/
+│   │       ├── Login.vue
+│   │       ├── Register.vue
+│   │       ├── ForgotPassword.vue
+│   │       ├── ResetPassword.vue
+│   │       └── VerifyEmail.vue
+│   ├── Components/
+│   │   └── Auth/
+│   │       └── AuthLayout.vue
+│   └── app.js
+├── css/
+│   └── app.css
+└── views/
+    └── app.blade.php
+```
+
 ## Customization
 
 ### Styling
 
 The authentication pages use Tailwind CSS classes. You can customize the styling by:
 
-1. Publishing the views: `php artisan vendor:publish --tag=laravel-subscription-assets`
-2. Modifying the Vue components in `resources/js/vendor/laravel-subscription/`
+1. Running the install command: `php artisan subscription:install-auth`
+2. Modifying the Vue components in `resources/js/Pages/Auth/` and `resources/js/Components/Auth/`
 
 ### Redirects
 
@@ -170,18 +194,26 @@ Ensure you've built your assets after installation:
 npm run build
 ```
 
+### Unable to locate file in Vite manifest
+
+If you see an error like "Unable to locate file in Vite manifest: resources/js/Pages/Auth/Login.vue", this means the authentication pages weren't properly published. Run:
+
+```bash
+php artisan subscription:install-auth --force
+npm run build
+```
+
 ### Styling issues
 
-Make sure Tailwind CSS is properly configured in your project and includes the package's Vue files in the content paths:
+Make sure Tailwind CSS is properly configured in your project. The install command creates a proper `tailwind.config.js`, but if you have custom configuration, ensure it includes:
 
 ```javascript
 // tailwind.config.js
-module.exports = {
+export default {
   content: [
     "./resources/**/*.blade.php",
     "./resources/**/*.js",
     "./resources/**/*.vue",
-    "./resources/js/vendor/laravel-subscription/**/*.vue", // Add this line
   ],
   // ...
 }


### PR DESCRIPTION
## 🔧 Problem Fixed

This PR resolves the **"Unable to locate file in Vite manifest: resources/js/Pages/Auth/Login.vue"** error that occurs when trying to access authentication pages.

### 🐛 **Root Cause**
The issue was caused by:
1. **Vite manifest lookup**: Vite was looking for auth pages in `resources/js/Pages/Auth/Login.vue`
2. **Vendor directory publishing**: Auth pages were published to `resources/js/vendor/laravel-subscription/`
3. **Complex page resolution**: app.js had complex vendor-specific page resolution logic
4. **Blade template issue**: app.blade.php was trying to load individual page files via Vite

### ✨ **Solution**

Simplified the entire approach to use standard Laravel/Inertia.js conventions:

#### 1. **Standard File Locations**
- ✅ Auth pages now published to: `resources/js/Pages/Auth/`
- ✅ Auth components published to: `resources/js/Components/Auth/`
- ✅ Standard Inertia.js file structure

#### 2. **Simplified Vite Configuration**
```html
<!-- Before: Complex per-page loading -->
@vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])

<!-- After: Standard entry points -->
@vite(['resources/css/app.css', 'resources/js/app.js'])
```

#### 3. **Standard Page Resolution**
```javascript
// Before: Complex vendor directory logic
resolve: (name) => {
  if (name.startsWith('Auth/')) {
    const authPagePath = `./vendor/laravel-subscription/Pages/${name}.vue`;
    if (authPages[authPagePath]) {
      return authPages[authPagePath]();
    }
  }
  return resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue'));
}

// After: Simple standard resolution
resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue'))
```

## 📁 **Files Changed**

### 🔄 **Modified**
- `src/Console/Commands/InstallAuthCommand.php`
  - Updated `publishAuthAssets()` to copy to main directories
  - Simplified `updateAppJs()` and `createAppJs()` methods
  - Updated `getAppLayoutContent()` for standard Vite entry points

- `AUTH_SETUP.md`
  - Added file structure documentation
  - Updated troubleshooting section with Vite manifest fix
  - Updated customization instructions for new file locations

## 🚀 **Benefits**

1. ✅ **Fixes Vite manifest error** - Pages are now in expected locations
2. ✅ **Standard Laravel conventions** - Uses normal Inertia.js file structure
3. ✅ **Simplified maintenance** - No complex vendor directory logic
4. ✅ **Better developer experience** - Auth pages in familiar locations
5. ✅ **Easier customization** - Direct access to auth components

## 🧪 **Testing**

### Before (Error)
```
Unable to locate file in Vite manifest: resources/js/Pages/Auth/Login.vue
```

### After (Working)
1. Run: `php artisan subscription:install-auth`
2. Run: `npm install && npm run build`
3. Visit: `/login` → ✅ **Works perfectly!**

## 📝 **File Structure**

After the fix, authentication files are organized as:

```
resources/
├── js/
│   ├── Pages/
│   │   └── Auth/          ← 🆕 Now in main directory
│   │       ├── Login.vue
│   │       ├── Register.vue
│   │       ├── ForgotPassword.vue
│   │       ├── ResetPassword.vue
│   │       └── VerifyEmail.vue
│   ├── Components/
│   │   └── Auth/          ← 🆕 Now in main directory
│   │       └── AuthLayout.vue
│   └── app.js             ← 🆕 Simplified resolution
├── css/
│   └── app.css
└── views/
    └── app.blade.php       ← 🆕 Standard Vite entries
```

## 🔄 **Migration for Existing Users**

For users who already installed the auth system and are experiencing this error:

```bash
# Re-run the install command with force flag
php artisan subscription:install-auth --force

# Rebuild assets
npm run build

# Clean up old vendor directory (optional)
rm -rf resources/js/vendor/laravel-subscription
```

## 🎆 **Impact**

- ✅ **Eliminates Vite manifest errors**
- ✅ **Follows Laravel/Inertia.js best practices**
- ✅ **Simplifies codebase maintenance**
- ✅ **Improves developer experience**
- ✅ **Maintains full functionality**

---

**This PR ensures authentication pages work seamlessly with Vite's build process and follow standard Laravel conventions.**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author