### PR TITLE
Fix method signature conflict in InstallAuthCommand

### DIFF
--- a/src/Console/Commands/InstallAuthCommand.php
+++ b/src/Console/Commands/InstallAuthCommand.php
@@ -577,7 +577,7 @@ new Ziggy)->toArray(),
 
         // Install dependencies
         $this->info('Running npm install...');
-        $process = $this->runCommand('npm install');
+        $process = $this->executeShellCommand('npm install');
 
         if ($process['success']) {
             $this->info('✓ NPM dependencies installed successfully');
@@ -585,7 +585,7 @@ new Ziggy)->toArray(),
             // Optionally run npm run build
             if ($this->confirm('Would you like to build the assets now?', true)) {
                 $this->info('Building assets...');
-                $buildProcess = $this->runCommand('npm run build');
+                $buildProcess = $this->executeShellCommand('npm run build');
 
                 if ($buildProcess['success']) {
                     $this->info('✓ Assets built successfully');
@@ -605,14 +605,14 @@ new Ziggy)->toArray(),
      */
     protected function isCommandAvailable(string $command): bool
     {
-        $process = $this->runCommand("which {$command}");
+        $process = $this->executeShellCommand("which {$command}");
         return $process['success'];
     }
 
     /**
-     * Run a shell command.
+     * Execute a shell command.
      */
-    protected function runCommand(string $command): array
+    protected function executeShellCommand(string $command): array
     {
         $descriptorspec = [
             0 => ['pipe', 'r'],  // stdin


### PR DESCRIPTION
## Problem

When installing this package on a Laravel application, users encounter a PHP Fatal error:

```
PHP Fatal error: Declaration of RiaanZA\LaravelSubscription\Console\Commands\InstallAuthCommand::runCommand(string $command): array must be compatible with Illuminate\Console\Command::runCommand($command, array $arguments, Symfony\Component\Console\Output\OutputInterface $output)
```

## Root Cause

The `InstallAuthCommand` class has a custom `runCommand()` method that conflicts with Laravel's built-in `runCommand()` method from the `Illuminate\Console\Command` class. The method signatures are incompatible:

- **Custom method:** `protected function runCommand(string $command): array`
- **Laravel's method:** `runCommand($command, array $arguments, Symfony\Component\Console\Output\OutputInterface $output)`

## Solution

Renamed the custom method from `runCommand()` to `executeShellCommand()` to avoid the naming conflict while maintaining all existing functionality.

## Changes Made

- ✅ Renamed `runCommand()` method to `executeShellCommand()` in `InstallAuthCommand.php`
- ✅ Updated all method calls (3 locations) to use the new method name:
  - NPM install command execution
  - NPM build command execution  
  - Command availability checking
- ✅ Updated method documentation

## Testing

The fix resolves the fatal error and allows the package to be installed successfully on Laravel applications. All existing functionality is preserved.

## Files Changed

- `src/Console/Commands/InstallAuthCommand.php`

Fixes the installation error reported by users when adding this package to their Laravel projects.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author