### PR TITLE
Fix: Add web middleware to auth routes to resolve session store error

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -16,7 +16,7 @@ use RiaanZA\LaravelSubscription\Http\Controllers\Auth\EmailVerificationControlle
 |
 */
 
-Route::middleware('guest')->group(function () {
+Route::middleware(['web', 'guest'])->group(function () {
     // Login Routes
     Route::get('login', [LoginController::class, 'create'])
         ->name('login');
@@ -43,7 +43,7 @@ Route::middleware('guest')->group(function () {
         ->name('password.store');
 });
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['web', 'auth'])->group(function () {
     // Email Verification Routes
     Route::get('verify-email', [EmailVerificationController::class, 'notice'])
         ->name('verification.notice');


### PR DESCRIPTION
## Problem
The authentication routes were experiencing a "Session store not set on request" error when posting login credentials from the frontend. This error occurred in `/src/Http/Controllers/Auth/LoginController.php` at line 39 when calling `$request->session()->regenerate()`.

## Root Cause
The authentication routes in `routes/auth.php` were missing the `web` middleware group, which provides session support. Without this middleware, the session store was not initialized, causing the session-related methods to fail.

## Solution
Added the `web` middleware to both route groups in `routes/auth.php`:

- **Guest routes**: Changed from `Route::middleware('guest')` to `Route::middleware(['web', 'guest'])`
- **Authenticated routes**: Changed from `Route::middleware('auth')` to `Route::middleware(['web', 'auth'])`

## Why This Fixes the Issue
The `web` middleware group includes:
- `StartSession` - Initializes the session store
- `ShareErrorsFromSession` - Shares validation errors
- `VerifyCsrfToken` - CSRF protection
- `SubstituteBindings` - Route model binding

By including the `web` middleware, the session store is properly initialized before authentication logic runs.

## Testing
After applying this fix:
1. Clear application cache: `lando php artisan cache:clear`
2. Clear route cache: `lando php artisan route:clear`
3. Test login functionality from the frontend

The "Session store not set on request" error should be resolved.

## Files Changed
- `routes/auth.php` - Added `web` middleware to route groups

## Impact
- ✅ Fixes session-related errors in authentication
- ✅ Maintains existing functionality
- ✅ No breaking changes
- ✅ Follows Laravel best practices for web routes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author