### PR TITLE
Fix: Add missing composables directory to install command

### DIFF
--- a/src/Console/Commands/InstallAuthCommand.php
+++ b/src/Console/Commands/InstallAuthCommand.php
@@ -117,6 +117,13 @@ class InstallAuthCommand extends Command
         }
         $this->copyDirectory($sourcePath . '/components', $lowercaseComponentsDestination);
 
+        // Copy composables directory
+        $composablesDestination = resource_path('js/composables');
+        if (!$this->files->isDirectory($composablesDestination)) {
+            $this->files->makeDirectory($composablesDestination, 0755, true);
+        }
+        $this->copyDirectory($sourcePath . '/composables', $composablesDestination);
+
         // Copy any additional JS files (like subscription.js)
         $additionalFiles = ['subscription.js'];
         foreach ($additionalFiles as $file) {


### PR DESCRIPTION
## Problem

The `subscription:install-auth` command was not copying the `composables` directory during installation, causing build errors when Vue components tried to import composables:

```
Could not resolve "../../composables/useErrorHandling.js" from "resources/js/Pages/Subscription/Checkout.vue"
```

## Solution

Added copying of the `composables` directory in `InstallAuthCommand::publishFrontendAssets()` method.

## Changes

- ✅ Added composables directory copying to ensure `useErrorHandling.js` and `useSuccessHandling.js` are available
- ✅ Maintains same pattern as other directory copying (creates directory if not exists)
- ✅ Resolves missing dependency issue when installing package on Laravel applications

## Files Changed

- `src/Console/Commands/InstallAuthCommand.php` - Added composables directory copying

## Testing

After this fix, the install command now copies:

1. ✅ Pages directory (`resources/js/Pages/`)
2. ✅ Components directory (`resources/js/Components/`)
3. ✅ components directory (`resources/js/components/`) - lowercase for standalone usage
4. ✅ **composables directory (`resources/js/composables/`)** - **FIXED**
5. ✅ subscription.js file

This ensures all Vue component imports work correctly after installation.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author